### PR TITLE
Allow a partial test name to fetch multiple logs at once

### DIFF
--- a/lib/src/get_log.dart
+++ b/lib/src/get_log.dart
@@ -38,9 +38,9 @@ Future<String> getLog(String builder, String build, String test) async {
         .map(jsonDecode)
         .toList();
     return logs
-        .where((log) => log["name"] == test)
+        .where((log) => log["name"].startsWith(test))
         .map((log) => log["log"])
-        .first;
+        .join("\n========================================================\n");
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
Fetches logs for all names that start with the entered test name.