### PR TITLE
Add configuration name to server and command line input. Allow wildcards

### DIFF
--- a/bin/log.dart
+++ b/bin/log.dart
@@ -4,7 +4,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Displays the log for a failing test on a given runner and build
-    
+
 import 'dart:async';
 import 'dart:io';
 
@@ -13,22 +13,24 @@ import 'package:args/args.dart';
 
 void main(List<String> args) {
   final parser = new ArgParser();
-  parser.addOption("builder",
-      abbr: "b",
-      help: "Fetch log from this builder");
+  parser.addOption("builder", abbr: "b", help: "Fetch log from this builder");
   parser.addOption("build-number",
       abbr: "n",
       defaultsTo: "latest",
       help: "Fetch log from this build on the chosen builder");
   parser.addOption("test",
-      abbr: "t",
-      help: "Fetch log for this test on the chosen builder");
+      abbr: "t", help: "Fetch log for this test on the chosen builder");
+  parser.addOption("configuration",
+      abbr: "c",
+      defaultsTo: "*",
+      help: "Limit logs to this configuration on the chosen builder");
   parser.addFlag("help", help: "Show the program usage.", negatable: false);
 
   final options = parser.parse(args);
   final builder = options["builder"];
   final test = options["test"];
   final build = options["build-number"];
+  final configuration = options["configuration"];
 
-  getLog(builder, build, test).then((log) => print(log));
+  getLog(builder, build, configuration, test).then((log) => print(log));
 }

--- a/bin/server.dart
+++ b/bin/server.dart
@@ -25,16 +25,20 @@ void logServer(HttpRequest request) async {
     }
     final parts = request.uri.pathSegments;
     final builder = parts[1];
-    final build = parts[2];
-    final test = parts.skip(3).join('/');
-    final log = await getLog(builder, build, test);
+    final configuration = parts[2];
+    final build = parts[3];
+    final test = parts.skip(4).join('/');
+    final log = await getLog(builder, build, configuration, test);
     if (log == null) {
       noLog(request, builder, build, test);
       return;
     }
     final response = request.response;
     response.headers.contentType = ContentType.text;
-    response.headers.expires = DateTime.now().add(Duration(days: 30));
+    var expires = DateTime.now();
+    if (build != 'latest') {
+      expires = expires.add(Duration(days: 30));
+    }
     response.write(log);
     response.close();
   } catch (e, t) {

--- a/bin/server.dart
+++ b/bin/server.dart
@@ -39,6 +39,7 @@ void logServer(HttpRequest request) async {
     if (build != 'latest') {
       expires = expires.add(Duration(days: 30));
     }
+    response.headers.expires = expires;    
     response.write(log);
     response.close();
   } catch (e, t) {


### PR DESCRIPTION
This makes the configuration name a mandatory part of the URL fetching a
log, and an optional argument to the command line tool.
Both the test name and configuration name inputs may now end with '*',
indicating they match any name that starts with that prefix.